### PR TITLE
feat(i18n): language picker modal, persistence, globe switch, RTL sup…

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tailwindcss/postcss": "^4.1.13",
         "i18next": "^25.5.2",
+        "i18next-browser-languagedetector": "^8.2.0",
         "i18next-http-backend": "^3.0.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -3331,7 +3332,6 @@
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.6"
       },
@@ -3342,6 +3342,14 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.0.tgz",
+      "integrity": "sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/i18next-http-backend": {
@@ -4711,7 +4719,6 @@
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.3.tgz",
       "integrity": "sha512-AANws4tOE+QSq/IeMF/ncoHlMNZaVLxpa5uUGW1wjike68elVYr0018L9xYoqBr1OFO7G7boDPrbn0HpMCJxTw==",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.6",
         "html-parse-stringify": "^3.0.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@tailwindcss/postcss": "^4.1.13",
     "i18next": "^25.5.2",
+    "i18next-browser-languagedetector": "^8.2.0",
     "i18next-http-backend": "^3.0.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import './i18n';
+import LanguagePicker from './components/LanguagePicker';
 
 // Import pages
 import Home from './pages/Home';
@@ -14,22 +15,39 @@ import Prescription from './pages/modules/Prescription';
 import TBA from './pages/modules/TBA';
 import NotFound from './pages/NotFound';
 
+
 function App() {
+  const [showPicker, setShowPicker] = useState(() => !localStorage.getItem('app.lang'));
+
+  useEffect(() => {
+    if (!localStorage.getItem('app.lang')) {
+      setShowPicker(true);
+    }
+  }, []);
+
+  const handleSelectLang = (code) => {
+    localStorage.setItem('app.lang', code);
+    window.location.reload(); // reload to re-init i18n and dir
+  };
+
   return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/auth/login" element={<Login />} />
-        <Route path="/auth/signup" element={<Signup />} />
-        <Route path="/auth/forgot-password" element={<ForgotPassword />} />
-        <Route path="/dashboard" element={<Dashboard />} />
-        <Route path="/settings/account" element={<Account />} />
-        <Route path="/modules/heart-risk" element={<HeartRisk />} />
-        <Route path="/modules/prescription" element={<Prescription />} />
-        <Route path="/modules/tba" element={<TBA />} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
-    </Router>
+    <>
+      {showPicker && <LanguagePicker onSelect={handleSelectLang} />}
+      <Router>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/auth/login" element={<Login />} />
+          <Route path="/auth/signup" element={<Signup />} />
+          <Route path="/auth/forgot-password" element={<ForgotPassword />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/settings/account" element={<Account />} />
+          <Route path="/modules/heart-risk" element={<HeartRisk />} />
+          <Route path="/modules/prescription" element={<Prescription />} />
+          <Route path="/modules/tba" element={<TBA />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </Router>
+    </>
   );
 }
 

--- a/frontend/src/components/LanguagePicker.jsx
+++ b/frontend/src/components/LanguagePicker.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import i18n from '../i18n';
+
+const LANGS = [
+  { code: 'en', label: 'English' },
+  { code: 'hi', label: 'हिन्दी' },
+  { code: 'es', label: 'Español' },
+  { code: 'ar', label: 'العربية' },
+  { code: 'zh', label: '中文' }
+];
+
+export default function LanguagePicker({ onSelect }) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
+      <div className="bg-white rounded-lg shadow-lg p-8 min-w-[300px] text-center">
+        <h2 className="text-xl font-bold mb-4">Select Language</h2>
+        <div className="flex flex-col gap-2">
+          {LANGS.map(lang => (
+            <button
+              key={lang.code}
+              className="py-2 px-4 rounded hover:bg-gray-100 text-lg"
+              onClick={() => onSelect(lang.code)}
+            >
+              {lang.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/PageShell.jsx
+++ b/frontend/src/components/PageShell.jsx
@@ -46,11 +46,30 @@ const PageShell = ({ children, title }) => {
               ))}
             <div className="flex items-center space-x-4">
             <div className="relative">
-              <button className="border rounded-full w-9 h-9 flex items-center justify-center" aria-label={t('common:language')} onClick={() => setOpen(o=>!o)}>🌐</button>
+              <button 
+                className="border rounded-full w-9 h-9 flex items-center justify-center hover:bg-gray-100 transition-colors" 
+                aria-label={t('common:language')} 
+                onClick={() => setOpen(o=>!o)}
+              >
+                🌐
+              </button>
               {open && (
-                <div className="absolute right-0 mt-2 bg-white border rounded-md shadow z-20 min-w-28">
+                <div className="absolute ltr:right-0 rtl:left-0 mt-2 bg-white border rounded-md shadow-lg z-20 min-w-28">
                   {['en','hi','es','ar','zh'].map(code => (
-                    <button key={code} className="px-3 py-2 text-left hover:bg-gray-50 w-full" onClick={() => { startTransition(()=>{ i18n.changeLanguage(code); localStorage.setItem('app.lang', code); document.documentElement.dir = code==='ar'?'rtl':'ltr'; setOpen(false); });}}>{code.toUpperCase()}</button>
+                    <button 
+                      key={code} 
+                      className="px-3 py-2 text-left rtl:text-right hover:bg-gray-50 w-full transition-colors block" 
+                      onClick={() => { 
+                        startTransition(()=>{ 
+                          i18n.changeLanguage(code); 
+                          localStorage.setItem('app.lang', code); 
+                          document.documentElement.dir = code==='ar'?'rtl':'ltr'; 
+                          setOpen(false); 
+                        });
+                      }}
+                    >
+                      {code.toUpperCase()}
+                    </button>
                   ))}
                 </div>
               )}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,1 +1,27 @@
 @import "tailwindcss";
+
+/* RTL/LTR Support Safeguards */
+[dir="rtl"] .ltr\:right-0 {
+  right: auto;
+  left: 0;
+}
+
+[dir="rtl"] .rtl\:left-0 {
+  left: 0;
+}
+
+[dir="rtl"] .rtl\:text-right {
+  text-align: right;
+}
+
+/* Ensure dropdown stays within viewport */
+.relative {
+  position: relative;
+}
+
+/* Language dropdown specific styles */
+.language-dropdown {
+  min-width: 7rem;
+  max-height: 16rem;
+  overflow-y: auto;
+}


### PR DESCRIPTION
1.Added react-i18next with support for en, hi, es, ar, zh .
2.Language picker modal appears on first visit, saves choice in localStorage.
3.Globe button in header for switching language at any time.
4.RTL layout is applied when Arabic is selected (dir="rtl" on root).
5.All language JSON keys are organized by namespace (common, auth, dashboard, modules).

<img width="1333" height="524" alt="image" src="https://github.com/user-attachments/assets/ec00719c-aebe-4b37-a9cf-662b1c58c955" />

<img width="1350" height="538" alt="image" src="https://github.com/user-attachments/assets/0935b6a3-3f01-4abe-abab-382ecc8b8135" />

Closes #2