### PR TITLE
Integration: forgot password wiring

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,0 +1,30 @@
+export const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
+
+async function parseJsonSafe(res) {
+  try {
+    return await res.json();
+  } catch (_) {
+    return null;
+  }
+}
+
+export async function apiPost(path, body) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  const json = await parseJsonSafe(res);
+  if (!res.ok) {
+    const msg = json?.error?.message || json?.message || `Request failed (${res.status})`;
+    const err = new Error(msg);
+    err.status = res.status;
+    err.body = json;
+    throw err;
+  }
+  return json?.data ?? json;
+}
+
+export default { apiPost };

--- a/frontend/src/pages/auth/ForgotPassword.jsx
+++ b/frontend/src/pages/auth/ForgotPassword.jsx
@@ -2,14 +2,7 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import PageShell from '../../components/PageShell';
-
-// small mock API that simulates sending a reset link
-const mockSendReset = (contact) =>
-  new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({ success: true, message: 'Password reset link sent.' });
-    }, 700);
-  });
+import { apiPost } from '../../lib/api';
 
 const ForgotPassword = () => {
   const { t } = useTranslation(['auth', 'common']);
@@ -29,15 +22,11 @@ const ForgotPassword = () => {
 
     setIsLoading(true);
     try {
-      // Replace this with a real API call when available
-      const res = await mockSendReset(trimmed);
-      if (res && res.success) {
-        setSent(true);
-      } else {
-        setError(res && res.message ? res.message : 'Failed to send reset link');
-      }
+      const data = await apiPost('/api/v1/auth/forgot-password', { phoneOrEmail: trimmed });
+      // backend returns data.message
+      setSent(true);
     } catch (err) {
-      setError('Failed to send reset link');
+      setError(err.message || 'Failed to send reset link');
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
This pull request adds backend integration and improves user feedback for the forgot password page. The main changes include creating a reusable API helper, connecting the forgot password form to the backend, and enhancing the UI to handle loading and error states.

**API integration and error handling:**

* Added a generic `apiPost` helper in `frontend/src/lib/api.js` for making POST requests and handling errors and JSON parsing.
* Connected the forgot password form to the backend by calling `apiPost('/api/v1/auth/forgot-password', { phoneOrEmail })` on submit, and handling API errors with user-friendly messages.

**UI/UX improvements:**

* Displayed error messages to users when the forgot password request fails, using a styled error box.
* Disabled the input field and submit button during API requests, and showed a loading state on the button.
<img width="1521" height="527" alt="image" src="https://github.com/user-attachments/assets/d29745f3-e763-441d-91fe-5c4e9d9e728f" />
