### PR TITLE
task(api): API Response Standardization

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, HTTPException, status, Depends, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from jose import jwt, JWTError
+from pydantic import BaseModel
 from pydantic_settings import BaseSettings
 from dotenv import load_dotenv
 from slowapi import Limiter, _rate_limit_exceeded_handler
@@ -261,6 +262,9 @@ async def upload_profile_photo(
 
     return SuccessResponse(data=current_user)
 
-@app.get("/healthz", tags=["System"])
+class HealthResponse(BaseModel):
+    status: str
+
+@app.get("/healthz", response_model=SuccessResponse[HealthResponse], tags=["System"])
 def health_check():
-    return {"success": True, "data": {"status": "ok"}}
+    return SuccessResponse(data={"status": "ok"})

--- a/docs/API_RESPONSE_STANDARD.md
+++ b/docs/API_RESPONSE_STANDARD.md
@@ -1,0 +1,146 @@
+# API Response Standard
+
+This document defines the standard response format for all API endpoints in TheHealthApp.
+
+## Response Format
+
+All API responses follow a consistent JSON structure with a `success` boolean and either `data` or `error` field.
+
+### Success Response
+
+```json
+{
+  "success": true,
+  "data": {
+    // Response payload here
+  }
+}
+```
+
+**Example - User Login:**
+```json
+{
+  "success": true,
+  "data": {
+    "user": {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "username": "johndoe",
+      "name": "John Doe",
+      "age": 25,
+      "gender": "male",
+      "phone": "1234567890",
+      "photo_url": null
+    },
+    "tokens": {
+      "access_token": "eyJhbGciOiJIUzI1NiIs...",
+      "refresh_token": "eyJhbGciOiJIUzI1NiIs...",
+      "token_type": "bearer"
+    }
+  }
+}
+```
+
+### Error Response
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "ERROR_CODE",
+    "message": "Human-readable error message",
+    "details": {}  // Optional additional context
+  }
+}
+```
+
+**Example - Validation Error:**
+```json
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Validation error in field 'age': value is not a valid integer",
+    "details": [
+      {
+        "loc": ["body", "age"],
+        "msg": "value is not a valid integer",
+        "type": "type_error.integer"
+      }
+    ]
+  }
+}
+```
+
+## HTTP Status Codes
+
+| Status | Usage |
+|--------|-------|
+| 200 | Successful GET, PATCH, POST (with body) |
+| 201 | Resource created (optional, 200 also acceptable) |
+| 204 | Successful DELETE or POST with no response body |
+| 400 | Bad request / malformed input |
+| 401 | Unauthorized / invalid credentials |
+| 403 | Forbidden / insufficient permissions |
+| 404 | Resource not found |
+| 409 | Conflict (e.g., duplicate username) |
+| 422 | Validation error |
+| 429 | Rate limit exceeded |
+| 500 | Internal server error |
+
+## Error Codes
+
+Standard error codes used in the `error.code` field:
+
+| Code | Description |
+|------|-------------|
+| `VALIDATION_ERROR` | Request validation failed |
+| `HTTP_ERROR` | General HTTP error |
+| `UNAUTHORIZED` | Authentication required |
+| `FORBIDDEN` | Access denied |
+| `NOT_FOUND` | Resource not found |
+| `CONFLICT` | Resource conflict (duplicates) |
+| `RATE_LIMITED` | Too many requests |
+| `SERVER_ERROR` | Internal server error |
+
+## Backend Implementation
+
+Use the `SuccessResponse` wrapper for all successful responses:
+
+```python
+from .models import SuccessResponse, UserResponse
+
+@app.get("/api/v1/users/me", response_model=SuccessResponse[UserResponse])
+async def get_own_profile(current_user: User):
+    return SuccessResponse(data=current_user)
+```
+
+Errors are automatically wrapped by the exception handlers in `main.py`.
+
+## Frontend Handling
+
+The API client automatically unwraps successful responses:
+
+```javascript
+// client.js response interceptor extracts response.data.data
+const user = await authService.getCurrentUser();
+// user is already the unwrapped data, not { success: true, data: {...} }
+```
+
+Error responses are mapped through `errorMapper.js`:
+
+```javascript
+// Error structure after mapping
+{
+  messageKey: 'errors.invalidCredentials',  // i18n key
+  message: 'Incorrect username or password', // Backend message
+  status: 401,
+  details: { ... }  // Optional
+}
+```
+
+## Adding New Endpoints
+
+1. Define response schema in `models.py`
+2. Use `SuccessResponse[YourSchema]` as the response_model
+3. Return `SuccessResponse(data=your_data)`
+4. Add any new error codes to `errorMapper.js` if needed

--- a/frontend/src/api/types.js
+++ b/frontend/src/api/types.js
@@ -1,0 +1,59 @@
+/**
+ * API Response Types
+ *
+ * Standard response format for all API endpoints.
+ * See /docs/API_RESPONSE_STANDARD.md for full documentation.
+ */
+
+/**
+ * @typedef {Object} ApiSuccessResponse
+ * @property {boolean} success - Always true for success responses
+ * @property {*} data - The response payload
+ */
+
+/**
+ * @typedef {Object} ApiErrorDetail
+ * @property {string} code - Error code (e.g., 'VALIDATION_ERROR', 'HTTP_ERROR')
+ * @property {string} message - Human-readable error message
+ * @property {Object|Array} [details] - Optional additional error context
+ */
+
+/**
+ * @typedef {Object} ApiErrorResponse
+ * @property {boolean} success - Always false for error responses
+ * @property {ApiErrorDetail} error - Error details
+ */
+
+/**
+ * @typedef {Object} MappedApiError
+ * @property {string} messageKey - i18n translation key for the error
+ * @property {string} message - Raw error message from backend
+ * @property {number} [status] - HTTP status code
+ * @property {Object|Array} [details] - Optional validation details
+ */
+
+/**
+ * @typedef {Object} TokenResponse
+ * @property {string} access_token - JWT access token
+ * @property {string} refresh_token - JWT refresh token
+ * @property {string} token_type - Token type (always 'bearer')
+ */
+
+/**
+ * @typedef {Object} UserResponse
+ * @property {string} id - User UUID
+ * @property {string} username - Username
+ * @property {string} name - Full name
+ * @property {number} age - User age
+ * @property {'male'|'female'|'other'|'na'} gender - Gender
+ * @property {string} phone - Phone number
+ * @property {string|null} photo_url - Profile photo URL
+ */
+
+/**
+ * @typedef {Object} AuthResponse
+ * @property {UserResponse} user - User data
+ * @property {TokenResponse} tokens - Auth tokens
+ */
+
+export {};


### PR DESCRIPTION
Closes #75

## Summary
Define and document the standard API response format used across the application.

## Changes
- **docs/API_RESPONSE_STANDARD.md**: New documentation defining the standard response format
- **backend/src/main.py**: Fixed `/healthz` endpoint to use `SuccessResponse` wrapper
- **frontend/src/api/types.js**: Added JSDoc type definitions for API responses

## Standard Format

**Success:**
```json
{ "success": true, "data": { ... } }
```

**Error:**
```json
{ "success": false, "error": { "code": "...", "message": "...", "details": {} } }
```

## Acceptance Criteria
- [x] Define standard API response format
- [x] Update frontend to match format (already aligned)
- [x] Align backend responses (healthz fixed)
- [x] Consistent API responses across application