### PR TITLE
feat(auth): implement token revocation and enhance MongoDB configuration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,10 @@
+# Application (copy to .env and set real values; never commit .env)
+# MongoDB - use same credentials as db service (see docker-compose)
+# MONGO_URL=mongodb://userh:YOUR_PASSWORD@db:27017
+# MONGO_DB_NAME=healthapp
+# JWT_ACCESS_SECRET=generate-a-strong-random-secret-for-access-tokens
+# JWT_REFRESH_SECRET=generate-a-different-strong-random-secret-for-refresh-tokens
+# ACCESS_TOKEN_EXPIRE_MINUTES=15
+# REFRESH_TOKEN_EXPIRE_DAYS=7
+# ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+# ALLOWED_ORIGIN_REGEX=

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -50,8 +50,9 @@ MAX_PHOTO_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB
 # --- 2. MODELS & SCHEMAS ---
 from .models import (
     User, UserCreate, UserLogin, SignupResponse, 
-    TokenRefresh, TokenResponse, ForgotPasswordRequest, ForgotPasswordResponse,
-    UserResponse, UserUpdate, ErrorDetail, ErrorResponse, SuccessResponse
+    TokenRefresh, TokenResponse, LogoutRequest, ForgotPasswordRequest, ForgotPasswordResponse,
+    UserResponse, UserUpdate, ErrorDetail, ErrorResponse, SuccessResponse,
+    RevokedToken,
 )
 
 limiter = Limiter(key_func=get_remote_address,default_limits=["100 per 15 minutes"])
@@ -60,39 +61,51 @@ security = HTTPBearer()
 
 def create_access_token(user_id: str) -> str:
     expire = datetime.now(timezone.utc) + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
-    to_encode = {"exp": expire, "sub": user_id}
+    jti = str(uuid.uuid4())
+    to_encode = {"exp": expire, "sub": user_id, "jti": jti}
     return jwt.encode(to_encode, settings.JWT_ACCESS_SECRET, algorithm="HS256")
 
 def create_refresh_token(user_id: str) -> str:
     expire = datetime.now(timezone.utc) + timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
-    to_encode = {"exp": expire, "sub": user_id}
+    jti = str(uuid.uuid4())
+    to_encode = {"exp": expire, "sub": user_id, "jti": jti}
     return jwt.encode(to_encode, settings.JWT_REFRESH_SECRET, algorithm="HS256")
 
-def verify_access_token(token: str) -> str:
+def verify_access_token(token: str) -> tuple[str, str]:
     try:
         payload = jwt.decode(token, settings.JWT_ACCESS_SECRET, algorithms=["HS256"])
         user_id = payload.get("sub")
+        jti = payload.get("jti") or ""
         if user_id is None:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Could not validate credentials")
-        return user_id
+        return user_id, jti
     except JWTError:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired access token")
 
-def verify_refresh_token(token: str) -> str:
+def verify_refresh_token(token: str) -> tuple[str, str]:
     try:
         payload = jwt.decode(token, settings.JWT_REFRESH_SECRET, algorithms=["HS256"])
         user_id = payload.get("sub")
+        jti = payload.get("jti") or ""
         if user_id is None:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
-        return user_id
+        return user_id, jti
     except JWTError:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+async def is_token_revoked(jti: str) -> bool:
+    if not jti:
+        return False
+    doc = await RevokedToken.find_one(RevokedToken.jti == jti)
+    return doc is not None
 
 async def get_current_user(
     credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)]
 ) -> User:
     token = credentials.credentials
-    user_id = verify_access_token(token)
+    user_id, jti = verify_access_token(token)
+    if await is_token_revoked(jti):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has been revoked")
     user = await User.get(uuid.UUID(user_id))
     if not user:
        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
@@ -102,7 +115,7 @@ async def get_current_user(
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     client = motor.motor_asyncio.AsyncIOMotorClient(settings.MONGO_URL)
-    await init_beanie(database=client[settings.MONGO_DB_NAME], document_models=[User])
+    await init_beanie(database=client[settings.MONGO_DB_NAME], document_models=[User, RevokedToken])
     print("Database connection established.")
     yield
 
@@ -195,7 +208,9 @@ async def login_user(request: Request, payload: UserLogin):
 @app.post("/api/v1/auth/refresh", response_model=SuccessResponse[TokenResponse], tags=["Authentication"])
 @limiter.limit("10/minute")
 async def refresh_access_token(request: Request, payload: TokenRefresh):
-    user_id = verify_refresh_token(payload.refresh_token)
+    user_id, jti = verify_refresh_token(payload.refresh_token)
+    if await is_token_revoked(jti):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has been revoked")
     return SuccessResponse(data={
         "access_token": create_access_token(user_id),
         "refresh_token": payload.refresh_token,
@@ -203,7 +218,25 @@ async def refresh_access_token(request: Request, payload: TokenRefresh):
     })
 
 @app.post("/api/v1/auth/logout", status_code=204, tags=["Authentication"])
-async def logout_user():
+async def logout_user(payload: LogoutRequest):
+    from datetime import datetime as dt
+    try:
+        _, jti_refresh = verify_refresh_token(payload.refresh_token)
+        if jti_refresh:
+            exp = jwt.get_unverified_claims(payload.refresh_token).get("exp")
+            exp_at = dt.fromtimestamp(exp, tz=timezone.utc) if exp else datetime.now(timezone.utc) + timedelta(days=7)
+            await RevokedToken(jti=jti_refresh, exp_at=exp_at).insert()
+    except (JWTError, HTTPException):
+        pass
+    if payload.access_token:
+        try:
+            _, jti_access = verify_access_token(payload.access_token)
+            if jti_access:
+                exp = jwt.get_unverified_claims(payload.access_token).get("exp")
+                exp_at = dt.fromtimestamp(exp, tz=timezone.utc) if exp else datetime.now(timezone.utc) + timedelta(minutes=15)
+                await RevokedToken(jti=jti_access, exp_at=exp_at).insert()
+        except (JWTError, HTTPException):
+            pass
     return None
 
 @app.post("/api/v1/auth/forgot-password", response_model=SuccessResponse[ForgotPasswordResponse], tags=["Authentication"])

--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -24,6 +24,14 @@ class User(Document):
     class Settings:
         name = "users"
 
+
+class RevokedToken(Document):
+    """Stores JWT IDs (jti) of revoked tokens until expiry. Used for logout / token blacklist."""
+    jti: Annotated[str, Indexed(unique=True)]
+    exp_at: datetime
+    class Settings:
+        name = "revoked_tokens"
+
 # --- API Schemas ---
 class UserCreate(BaseModel):
     username: Annotated[str, StringConstraints(min_length=2, max_length=50)]
@@ -49,6 +57,11 @@ class UserLogin(BaseModel):
 
 class TokenRefresh(BaseModel):
     refresh_token: str
+
+
+class LogoutRequest(BaseModel):
+    refresh_token: str
+    access_token: Optional[str] = None
 
 class ForgotPasswordRequest(BaseModel):
     phoneOrEmail: str

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
 version: '3.8'
 
+# MongoDB credentials must be set via environment (e.g. in .env or CI).
+# Example: MONGO_INITDB_ROOT_USERNAME=userh MONGO_INITDB_ROOT_PASSWORD=your-secret docker-compose up
+
 services:
   # MongoDB Service
   db:
@@ -7,8 +10,8 @@ services:
     container_name: healthapp_mongo_db
     restart: always
     environment:
-      - MONGO_INITDB_ROOT_USERNAME=userh
-      - MONGO_INITDB_ROOT_PASSWORD=Password123
+      - MONGO_INITDB_ROOT_USERNAME=${MONGO_INITDB_ROOT_USERNAME:-userh}
+      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD:?Set MONGO_INITDB_ROOT_PASSWORD in .env or environment}
     ports:
       - "27018:27017"
     volumes:
@@ -23,6 +26,8 @@ services:
       - "8000:8000"
     depends_on:
       - db
+    env_file:
+      - ./backend/.env
 
 volumes:
   mongo_data:


### PR DESCRIPTION
- Added RevokedToken model to store JWT IDs of revoked tokens for logout functionality.
- Updated authentication flow to check for revoked tokens during access and refresh token verification.
- Modified Docker Compose configuration to use environment variables for MongoDB credentials and added support for .env file.
- Enhanced logout endpoint to revoke tokens by storing their IDs in the database.

This update improves security by ensuring that revoked tokens cannot be used for authentication.

Closes #73  